### PR TITLE
Updated ChangePassword to route to /Login not /

### DIFF
--- a/frontend/platoon-console/src/pages/ChangePassword.jsx
+++ b/frontend/platoon-console/src/pages/ChangePassword.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { useState, useEffect } from 'react';
 import { Form, FormGroup, Input, Button } from 'reactstrap';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 
 const ChangePassword = () => {
 
@@ -40,9 +40,7 @@ const ChangePassword = () => {
                         'token': tokenPart  // Set tokenPart as the value of 'token' header
                     }
             });
-            // const { token } = response.data;
-
-            localStorage.setItem('token', token);
+            console.log(response)
 
             setErrorMessage("");
             setSuccessMessage(response.data.message);
@@ -50,7 +48,7 @@ const ChangePassword = () => {
             setVerifyPassword("");
             
             setTimeout(() => {
-                navigate("/");
+                navigate("/login");
             }, 2000);
 
             console.log(response)
@@ -97,6 +95,7 @@ const ChangePassword = () => {
                 {successMessage ? (
                     <>
                         <p style={{ color: 'green' }}>{successMessage}</p>
+                        
                     </>
                 ) : (
                     <>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Refactor
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Other (please specify here: <type here>)
  
  
## Description of what this Pull Request does
ChangePassword was trying to set token and log user in but no token was being provided response.data.  Instead, it was grabbing the "token" from the reset pw URL.  Thus, an unauthenticated user was being "logged in" and routed to Homepage.  

Changed ChangePassword to stop storing false token and route user to /login on successful pw reset, forcing an authenticated login.


## Related Tickets & Documents
- Closes #100 
